### PR TITLE
Separate Ruff Linter into Parallel Job in CI Workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,11 +2,12 @@ name: CI
 
 on:
   push:
-    branches:
-      - main
+    branches: [main]
   pull_request:
-    branches:
-      - main
+  workflow_dispatch:
+
+env:
+  PYTHON_VERSION: "3.12"
 
 jobs:
   test:
@@ -16,7 +17,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.12'
+        python-version: ${{ env.PYTHON_VERSION }}
     - name: Install uv
       uses: astral-sh/setup-uv@v3
       with:
@@ -30,6 +31,22 @@ jobs:
       run: uv run python backend/manage.py collectstatic --noinput
     - name: Run Tests
       run: uv run pytest
+
+  ruff:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Setup Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ env.PYTHON_VERSION }}
+    - name: Install uv
+      uses: astral-sh/setup-uv@v3
+      with:
+        enable-cache: true
+        version: "latest"
+    - name: Install dependencies
+      run: uv sync --locked
     - name: Run ruff
       run: |
         source .venv/bin/activate


### PR DESCRIPTION
**Title**: Separate Ruff Linter into Parallel Job in CI Workflow

**Description**:
This pull request refactors our GitHub Actions CI workflow to run the `ruff` linter as a parallel job instead of making it dependent on the `test` job. The objective is to streamline the CI pipeline and reduce the overall execution time by running the linting process concurrently with the tests.

**Changes**:
- Created a new job for running `ruff` as a parallel job.
- Both jobs now share similar setup steps (e.g., Python and dependencies installation), but the `ruff` job focuses only on linting and formatting.

**Key Benefits**:
- Speeds up the CI pipeline by executing tests and linting at the same time.
- Improves efficiency and productivity during development cycles.